### PR TITLE
Fixed hostname resolution

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1620,7 +1620,7 @@ class gpload:
             # do default host, the current one
             if not local_hostname:
                 try:
-                    pipe = subprocess.Popen("hostname",
+                    pipe = subprocess.Popen(["hostname","-f"],
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE)
                     result  = pipe.communicate();


### PR DESCRIPTION
The original gpload hostname resolution wasn't using the fully qualified domain name which could be a problem if the greenplum server and the ETL nodes are in different domain, which can easily happen in an enterprise installation. This patch fixes that.